### PR TITLE
Add new Override Worker Count and Threads Feature

### DIFF
--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -13,6 +13,10 @@ sys.stdout.reconfigure(encoding='utf-8')
 # Add a check to see what encoders are available. Make a nice opening message saying
 # Av1anStaxRip, Supported Encoders....
 # FileNotFoundError is the error when using subprocess.run
+# TODO: Update docs on Override Workers and Affinity per Local Computer (for networked use-case)
+# TODO: Finish set_worker_override() (including command line option)
+# TODO: Allow separate override for workers and affinity
+# TODO: Force close av1an when StaxRip terminates the script
 
 
 # Functions

--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -100,6 +100,7 @@ def get_worker_override():
                 if not isinstance(workers, int) or not isinstance(affinity, int):
                     raise ValueError("[ERROR] override-workers.json is not formatted correctly")
                 print(f"[INFO] Overriding CPU Workers = {workers} and CPU Thread Affinity = {affinity}")
+                print("[INFO] Automatic Thread Detection Disabled")
                 return (True, workers, affinity)
         except Exception as error:
             print("[ERROR] Failed to read override-workers.json. Skipping...")
@@ -151,6 +152,8 @@ override_workers, cpu_workers, cpu_thread_affinity = get_worker_override()
 
 if not parser_args.disable_automatic_thread_detection and parser_args.workers is None and parser_args.set_thread_affinity is None and not override_workers:
     thread_detection = True
+else:
+    print("[INFO] Automatic Thread Detection Disabled")
 
 if thread_detection: # Checking for new Intel architecture
     import psutil
@@ -158,7 +161,8 @@ if thread_detection: # Checking for new Intel architecture
     physical_count = psutil.cpu_count(logical = False)
     if (logical_count / physical_count) % 1 != 0:
         thread_detection = False  # Intel CPU detected
-        print("New Intel CPU architecture with performance and efficiency cores detected!\nNot passing thread detection to av1an...\n")
+        print("[INFO] New Intel CPU architecture with P and E cores detected! Not passing thread detection to av1an...\n")
+        print("[INFO] Automatic Thread Detection Disabled")
     
 if thread_detection: # Checking for Hyperthreading or SMT
     import psutil

--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -100,7 +100,6 @@ def get_worker_override():
         except BaseException as error:
             print("[ERROR] Failed to read override-workers.json. Skipping...")
             print(error)
-            return (False, 0, 0)
     return (False, 0, 0)
 
 def set_worker_override(): # Function to create override-workers.json

--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -10,11 +10,11 @@ sys.stdout.reconfigure(encoding='utf-8')
 # Use the -e flag to specify the encoder and make sure .exe is in the specific folders. https://github.com/Kidsnd274/Av1anStaxRipWrapper
 
 
+# Developer Notes:
 # Add a check to see what encoders are available. Make a nice opening message saying
 # Av1anStaxRip, Supported Encoders....
 # FileNotFoundError is the error when using subprocess.run
 # TODO: Update docs on Override Workers and Affinity per Local Computer (for networked use-case)
-# TODO: Finish set_worker_override() (including command line option)
 # TODO: Allow separate override for workers and affinity
 # TODO: Force close av1an when StaxRip terminates the script
 
@@ -176,9 +176,14 @@ parser.add_argument('--pix-format', dest="pix_format", type=str, required=False,
 parser.add_argument('--workers', type=str, required=False, help="Number of workers to spawn [0 = automatic] (Av1an Paramter)")
 parser.add_argument('--set-thread-affinity', dest="set_thread_affinity", type=str, required=False, help="Pin each worker to a specific set of threads of this size (disabled by default) (Av1an parameter)")
 parser.add_argument('--disable-automatic-thread-detection', dest="disable_automatic_thread_detection", action='store_true', help="Disable the wrapper's automatic thread detection")
+parser.add_argument('--set-worker-override', dest="override_mode", action='store_true', help="Set the override workers count and thread affinity count for local computer")
 parser_args = parser.parse_args()
 
 print_welcome()
+
+if parser_args.override_mode:
+    set_worker_override()
+    exit()
 
 if parser_args.version:
     print_version(parser_args)

--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -97,7 +97,7 @@ def get_worker_override():
                 config = json.load(f)
                 workers = config.get('cpu_workers')
                 affinity = config.get('cpu_thread_affinity')
-                print(f"[INFO] Overriding CPU Workers as {workers} and CPU Thread Affinity as {affinity}")
+                print(f"[INFO] Overriding CPU Workers = {workers} and CPU Thread Affinity = {affinity}")
                 return (True, workers, affinity)
         except BaseException as error:
             print("[ERROR] Failed to read override-workers.json. Skipping...")

--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -85,8 +85,6 @@ def print_version(parser_args):
 def get_worker_override():
     # Check for override-workers.json
     # eg. cpu_workers = 2, cpu_thread_affinity = 2
-    ## If not found, return False, 0, 0
-    ## If found, return True, workers, cpu_thread_affinity
     local_app_data_path = pathlib.Path(os.getenv('LOCALAPPDATA'))
     config_path = local_app_data_path / "Av1anStaxRipWrapper" / "override-workers.json"
     if config_path.is_file():

--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -14,7 +14,6 @@ sys.stdout.reconfigure(encoding='utf-8')
 # Add a check to see what encoders are available. Make a nice opening message saying
 # Av1anStaxRip, Supported Encoders....
 # FileNotFoundError is the error when using subprocess.run
-# TODO: Update docs on Override Workers and Affinity per Local Computer (for networked use-case)
 # TODO: Allow separate override for workers and affinity
 # TODO: Force close av1an when StaxRip terminates the script
 

--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -89,7 +89,7 @@ def print_version(parser_args):
 def get_worker_override():
     # Check for override-workers.json
     # eg. cpu_workers = 2, cpu_thread_affinity = 2
-    local_app_data_path = pathlib.Path(os.getenv('LOCALAPPDATA'))
+    local_app_data_path = pathlib.Path(str(os.getenv('LOCALAPPDATA')))
     config_path = local_app_data_path / "Av1anStaxRipWrapper" / "override-workers.json"
     if config_path.is_file():
         print("[INFO] Found override-workers.json")
@@ -103,8 +103,7 @@ def get_worker_override():
                     raise KeyError("[ERROR] override-workers.json is does not contain cpu_workers or cpu_thread_affinity")
                 if not isinstance(workers, int) or not isinstance(affinity, int):
                     raise ValueError("[ERROR] override-workers.json is not formatted correctly")
-                print(f"[INFO] Overriding CPU Workers = {workers} and CPU Thread Affinity = {affinity}")
-                print("[INFO] Automatic Thread Detection Disabled")
+                print(f"[INFO] Overriding CPU Workers = {str(workers)} and CPU Thread Affinity = {str(affinity)}")
                 return (True, workers, affinity)
         except Exception as error:
             print("[ERROR] Failed to read override-workers.json. Skipping...")
@@ -112,7 +111,50 @@ def get_worker_override():
     return (False, 0, 0)
 
 def set_worker_override(): # Function to create override-workers.json
-    pass
+    print("Setting override workers and thread affinity for local computer...")
+    print("")
+    print("How many workers do you want to spawn? (Put 0 for disabled)")
+    while True:
+        workers = input("cpu_workers = ")
+        try:
+            workers_int = int(workers)
+            if workers_int < 0:
+                raise ValueError
+        except ValueError:
+            print("Invalid input, please enter a positive number")
+            continue
+        else:
+            break
+    print("How many threads do you want to pin each worker to? (Put 0 for disabled)")
+    while True:
+        affinity = input("cpu_thread_affinity = ")
+        try:
+            affinity_int = int(affinity)
+            if affinity_int < 0:
+                raise ValueError
+        except ValueError:
+            print("Invalid input, please enter a positive number")
+            continue
+        else:
+            break
+    
+    config = {}
+    if workers_int != 0:
+        config['cpu_workers'] = workers_int
+    if affinity_int != 0:
+        config['cpu_thread_affinity'] = affinity_int
+    
+    import json
+    local_app_data_path = pathlib.Path(str(os.getenv('LOCALAPPDATA')))
+    config_path = local_app_data_path / "Av1anStaxRipWrapper" / "override-workers.json"
+    
+    # Creating proper folders and files
+    config_path.parent.mkdir(parents=False, exist_ok=True)
+    config_path.touch(exist_ok=True)
+    with open(config_path) as f:
+        json.dump(config, f, indent=4)
+    print(f"Successfully written to {str(config_path)}")
+    exit()
 
 # Command Line Arguments
 parser = argparse.ArgumentParser(description="Av1an wrapper for StaxRip")

--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -151,7 +151,7 @@ def set_worker_override(): # Function to create override-workers.json
     # Creating proper folders and files
     config_path.parent.mkdir(parents=False, exist_ok=True)
     config_path.touch(exist_ok=True)
-    with open(config_path) as f:
+    with config_path.open('w') as f:
         json.dump(config, f, indent=4)
     print(f"Successfully written to {str(config_path)}")
     exit()

--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -96,9 +96,9 @@ def get_worker_override():
                 workers = config.get('cpu_workers')
                 affinity = config.get('cpu_thread_affinity')
                 if workers is None or affinity is None:
-                    raise KeyError("override-workers.json is does not contain cpu_workers or cpu_thread_affinity")
-                if type(workers) != int or type(affinity) != int:
-                    raise ValueError("override-workers.json is not formatted correctly")
+                    raise KeyError("[ERROR] override-workers.json is does not contain cpu_workers or cpu_thread_affinity")
+                if not isinstance(workers, int) or not isinstance(affinity, int):
+                    raise ValueError("[ERROR] override-workers.json is not formatted correctly")
                 print(f"[INFO] Overriding CPU Workers = {workers} and CPU Thread Affinity = {affinity}")
                 return (True, workers, affinity)
         except Exception as error:

--- a/Av1anStaxRipWrapper.py
+++ b/Av1anStaxRipWrapper.py
@@ -95,9 +95,13 @@ def get_worker_override():
                 config = json.load(f)
                 workers = config.get('cpu_workers')
                 affinity = config.get('cpu_thread_affinity')
+                if workers is None or affinity is None:
+                    raise KeyError("override-workers.json is does not contain cpu_workers or cpu_thread_affinity")
+                if type(workers) != int or type(affinity) != int:
+                    raise ValueError("override-workers.json is not formatted correctly")
                 print(f"[INFO] Overriding CPU Workers = {workers} and CPU Thread Affinity = {affinity}")
                 return (True, workers, affinity)
-        except BaseException as error:
+        except Exception as error:
             print("[ERROR] Failed to read override-workers.json. Skipping...")
             print(error)
     return (False, 0, 0)

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Av1anStaxRipWrapper
 https://github.com/Kidsnd274/Av1anStaxRipWrapper
 =================================================
 [INFO] Found override-workers.json
-[INFO] Overriding CPU Workers = 4 and CPU Thread Affinity = 4
+[INFO] Overriding CPU Workers = 4 and CPU Thread Affinity = 2
 [INFO] Automatic Thread Detection Disabled
 THREADING INFORMATION:
   Automatic Thread Detection: DISABLED

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ If you do not want to use this feature, you can use the `--disable-automatic-thr
 ## Override Worker Count and Threads Per Local Machine
 When using StaxRip in a networked environment (where multiple computers access the same StaxRip install), you might want to override the Automatic Thread Detection feature for some computers, but not affect other machines. This feature allows you to do so without modifying the command line option, by storing a configuration file in a local computer.
 
+* Note that this will override the `--workers` and `--set-thread-affinity` flags for the script. If you include these flags in the `--other-args` flag, both of them will be sent to Av1an. Not sure what will happen there but you are welcome to find out.
+
 ### Setting the override worker count
 To set the override feature, run the script with the `--set-worker-override` flag.
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Python wrapper script to use Av1an with StaxRip
   - [Override Worker Count and Threads Per Local Machine](#override-worker-count-and-threads-per-local-machine)
     - [Setting the override worker count](#setting-the-override-worker-count)
     - [Check to see if it's working](#check-to-see-if-its-working)
+    - [Structure of override-workers.json](#structure-of-override-workersjson)
 
 ## Usage
 This script makes use of the Command Line option in StaxRip. There are some required arguments needed in the command that allows Av1an to work with StaxRip. Namely `-i "%source_file%" -o "%encoder_out_file%" -t "%temp_dir%av1an_temp"`. `-s "%startup_dir%"` is needed if you want a portable installation. Portable installation is described in more detail at the [Setup](#setup) section.
@@ -156,7 +157,7 @@ To set the override feature, run the script with the `--set-worker-override` fla
 ```
 python Av1anStaxRipWrapper.py --set-worker-override
 ```
-Follow the instructions shown in the cmd window and the script should store a configuration file in this location. `%userprofile%\Av1anStaxRipWrapper\override-workers.json`
+Follow the instructions shown in the cmd window and the script should store a configuration file in this location. `%LOCALAPPDATA%\Av1anStaxRipWrapper\override-workers.json`
 
 ### Check to see if it's working
 The next time a job is being run, the script will show in its logs that the override file is found. For example:
@@ -171,4 +172,14 @@ https://github.com/Kidsnd274/Av1anStaxRipWrapper
 THREADING INFORMATION:
   Automatic Thread Detection: DISABLED
 Starting av1an... Check new console window for progress
+```
+
+### Structure of override-workers.json
+The json file stores two keys for worker count and thread affinity. (at the moment both keys must exist) The values must be in integers.
+Example:
+```
+{
+    "cpu_workers": 4,
+    "cpu_thread_affinity": 4
+}
 ```

--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ Python wrapper script to use Av1an with StaxRip
   - [Usage](#usage)
   - [Requirements](#requirements)
   - [Setup](#setup)
-    - [Portable Installation](#portable-installation)
+    - [Portable Installation (Recommended)](#portable-installation-recommended)
     - [Alternative Installation (install tools to system PATH)](#alternative-installation-install-tools-to-system-path)
   - [Command Line Options](#command-line-options)
   - [Automatic Thread Detection](#automatic-thread-detection)
+  - [Override Worker Count and Threads Per Local Machine](#override-worker-count-and-threads-per-local-machine)
+    - [Setting the override worker count](#setting-the-override-worker-count)
+    - [Check to see if it's working](#check-to-see-if-its-working)
 
 ## Usage
 This script makes use of the Command Line option in StaxRip. There are some required arguments needed in the command that allows Av1an to work with StaxRip. Namely `-i "%source_file%" -o "%encoder_out_file%" -t "%temp_dir%av1an_temp"`. `-s "%startup_dir%"` is needed if you want a portable installation. Portable installation is described in more detail at the [Setup](#setup) section.
@@ -116,6 +119,8 @@ optional arguments:
                         parameter)
   --disable-automatic-thread-detection
                         Disable the wrapper's automatic thread detection
+  --set-worker-override
+                        Set the override workers count and thread affinity count for local computer
 ```
 
 ## Automatic Thread Detection
@@ -140,3 +145,28 @@ Intel i5-6600K
 If your system uses an Intel 12th Gen chip and above (with the new hybrid architecture with P-cores and E-cores), this feature is disabled.
 
 If you do not want to use this feature, you can use the `--disable-automatic-thread-detection` flag or any of the Threading parameters under [Command Line Options](#command-line-options). Using any the Threading parameters would disable this feature.
+
+## Override Worker Count and Threads Per Local Machine
+When using StaxRip in a networked environment (where multiple computers access the same StaxRip install), you might want to override the Automatic Thread Detection feature for some computers, but not affect other machines. This feature allows you to do so without modifying the command line option, by storing a configuration file in a local computer.
+
+### Setting the override worker count
+To set the override feature, run the script with the `--set-worker-override` flag.
+```
+python Av1anStaxRipWrapper.py --set-worker-override
+```
+Follow the instructions shown in the cmd window and the script should store a configuration file in this location. `%userprofile%\Av1anStaxRipWrapper\override-workers.json`
+
+### Check to see if it's working
+The next time a job is being run, the script will show in its logs that the override file is found. For example:
+```
+=================================================
+Av1anStaxRipWrapper
+https://github.com/Kidsnd274/Av1anStaxRipWrapper
+=================================================
+[INFO] Found override-workers.json
+[INFO] Overriding CPU Workers = 4 and CPU Thread Affinity = 4
+[INFO] Automatic Thread Detection Disabled
+THREADING INFORMATION:
+  Automatic Thread Detection: DISABLED
+Starting av1an... Check new console window for progress
+```


### PR DESCRIPTION
Allows a user to add a configuration file to override the automatic thread detection feature (and the `--workers` and `--set-thread-affinity` flag.

- Script will read from `%LOCALAPPDATA%\Av1anStaxRipWrapper\override-workers.json`  to override worker count and thread affinity
- New `--set-worker-override` flag to automatically create the override-workers.json file
- Update README with these changes